### PR TITLE
Rely on ngrok's built-in retry mechanism for "failed to reconnect session" instead of forcing the binary to restart.

### DIFF
--- a/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
@@ -62,7 +62,6 @@ public class JavaNgrokConfig {
     private final int maxLogs;
     private final Function<NgrokLog, Void> logEventCallback;
     private final int startupTimeout;
-    private final int reconnectSessionRetries;
 
     private JavaNgrokConfig(final Builder builder) {
         this.ngrokPath = builder.ngrokPath;
@@ -73,7 +72,6 @@ public class JavaNgrokConfig {
         this.maxLogs = builder.maxLogs;
         this.logEventCallback = builder.logEventCallback;
         this.startupTimeout = builder.startupTimeout;
-        this.reconnectSessionRetries = builder.reconnectSessionRetries;
     }
 
     /**
@@ -133,14 +131,6 @@ public class JavaNgrokConfig {
     }
 
     /**
-     * Get the max number of times to retry establishing a new session with <code>ngrok</code> if the connection
-     * fails on startup.
-     */
-    public int getReconnectSessionRetries() {
-        return reconnectSessionRetries;
-    }
-
-    /**
      * Builder for a {@link JavaNgrokConfig}, see docs for that class for example usage.
      */
     public static class Builder {
@@ -153,7 +143,6 @@ public class JavaNgrokConfig {
         private int maxLogs = 100;
         private Function<NgrokLog, Void> logEventCallback;
         private int startupTimeout = 15;
-        private int reconnectSessionRetries = 0;
 
         public Builder() {
         }
@@ -172,7 +161,6 @@ public class JavaNgrokConfig {
             this.maxLogs = javaNgrokConfig.maxLogs;
             this.logEventCallback = javaNgrokConfig.logEventCallback;
             this.startupTimeout = javaNgrokConfig.startupTimeout;
-            this.reconnectSessionRetries = javaNgrokConfig.reconnectSessionRetries;
         }
 
         /**
@@ -246,19 +234,6 @@ public class JavaNgrokConfig {
             }
 
             this.startupTimeout = startupTimeout;
-            return this;
-        }
-
-        /**
-         * The max number of times to retry establishing a new session with <code>ngrok</code> if the connection
-         * fails on startup.
-         */
-        public Builder withReconnectSessionRetries(final int reconnectSessionRetries) {
-            if (reconnectSessionRetries < 0) {
-                throw new IllegalArgumentException("\"reconnectSessionRetries\" cannot be less than 0.");
-            }
-
-            this.reconnectSessionRetries = reconnectSessionRetries;
             return this;
         }
 

--- a/src/main/java/com/github/alexdlaird/ngrok/process/NgrokProcess.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/process/NgrokProcess.java
@@ -142,8 +142,10 @@ public class NgrokProcess {
                 if (processMonitor.isHealthy()) {
                     LOGGER.info(String.format("ngrok process has started with API URL: %s", processMonitor.apiUrl));
 
+                    processMonitor.startupError = null;
+
                     break;
-                } else if (nonNull(processMonitor.startupError) || !process.isAlive()) {
+                } else if (!process.isAlive()) {
                     break;
                 }
             }
@@ -153,24 +155,14 @@ public class NgrokProcess {
                 stop();
 
                 if (nonNull(processMonitor.startupError)) {
-                    final List<NgrokLog> logs = processMonitor.getLogs();
-                    final String lastLogMsg = logs.size() > 0 ? logs.get(logs.size() - 1).getMsg() : null;
-                    if (nonNull(lastLogMsg) && lastLogMsg.equals("failed to reconnect session")
-                            && retries < javaNgrokConfig.getReconnectSessionRetries()) {
-                        LOGGER.fine("ngrok reset our connection, retrying in 0.5 seconds ...");
-                        wait(500);
-
-                        start(retries + 1);
-                    } else {
-                        throw new NgrokException(String.format("The ngrok process errored on start: %s.", processMonitor.startupError),
-                                processMonitor.logs,
-                                processMonitor.startupError);
-                    }
+                    throw new NgrokException(String.format("The ngrok process errored on start: %s.", processMonitor.startupError),
+                            processMonitor.logs,
+                            processMonitor.startupError);
                 } else {
                     throw new NgrokException("The ngrok process was unable to start.", processMonitor.logs);
                 }
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException e) {
             throw new NgrokException("An error occurred while starting ngrok.", e);
         }
     }
@@ -421,7 +413,7 @@ public class NgrokProcess {
                 return false;
             }
 
-            return process.isAlive() && isNull(startupError);
+            return process.isAlive();
         }
 
         private void logStartupLine(final String line) {

--- a/src/main/java/com/github/alexdlaird/ngrok/process/NgrokProcess.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/process/NgrokProcess.java
@@ -45,7 +45,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.github.alexdlaird.util.StringUtils.isBlank;
-import static com.github.alexdlaird.util.StringUtils.isNotBlank;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -366,8 +365,9 @@ public class NgrokProcess {
 
                     if (isHealthy()) {
                         break;
-                    } else if (isNotBlank(startupError)) {
-                        return;
+                    } else if (nonNull(startupError)) {
+                        alive = false;
+                        break;
                     }
                 }
 

--- a/src/test/java/com/github/alexdlaird/ngrok/NgrokTestCase.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/NgrokTestCase.java
@@ -19,7 +19,6 @@ public class NgrokTestCase {
 
     protected JavaNgrokConfig javaNgrokConfig = new JavaNgrokConfig.Builder()
             .withConfigPath(Paths.get("build", ".ngrok2", "config.yml").toAbsolutePath())
-            .withReconnectSessionRetries(10)
             .build();
 
     protected NgrokInstaller ngrokInstaller = new NgrokInstaller();

--- a/src/test/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfigTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfigTest.java
@@ -30,7 +30,6 @@ public class JavaNgrokConfigTest {
                 .withMaxLogs(50)
                 .withLogEventCallback(logEventCallback)
                 .withStartupTimeout(5)
-                .withReconnectSessionRetries(6)
                 .build();
 
         // THEN
@@ -42,7 +41,6 @@ public class JavaNgrokConfigTest {
         assertEquals(50, javaNgrokConfig.getMaxLogs());
         assertEquals(logEventCallback, javaNgrokConfig.getLogEventCallback());
         assertEquals(5, javaNgrokConfig.getStartupTime());
-        assertEquals(6, javaNgrokConfig.getReconnectSessionRetries());
     }
 
     @Test
@@ -55,11 +53,5 @@ public class JavaNgrokConfigTest {
     public void testJavaNgrokConfigWithInvalidStartupTimeout() {
         // WHEN
         assertThrows(IllegalArgumentException.class, () -> new JavaNgrokConfig.Builder().withStartupTimeout(0));
-    }
-
-    @Test
-    public void testJavaNgrokConfigWithInvalidReconnectSessionRetries() {
-        // WHEN
-        assertThrows(IllegalArgumentException.class, () -> new JavaNgrokConfig.Builder().withReconnectSessionRetries(-1));
     }
 }


### PR DESCRIPTION
Address issue #4.