### PR TITLE
Add module-info.java

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+module com.github.alexdlaird.ngrok {
+    requires java.logging;
+    requires com.google.gson;
+    requires org.yaml.snakeyaml;
+
+    exports com.github.alexdlaird.exception;
+    exports com.github.alexdlaird.http;
+    exports com.github.alexdlaird.ngrok;
+    exports com.github.alexdlaird.ngrok.conf;
+    exports com.github.alexdlaird.ngrok.installer;
+    exports com.github.alexdlaird.ngrok.process;
+    exports com.github.alexdlaird.ngrok.protocol;
+    exports com.github.alexdlaird.util;
+}


### PR DESCRIPTION
Adding module-info.java file in an attempt to fix issue #48.

This version uses `com.github.alexdlaird.ngrok` as the module name and exports all packages, which I'm not sure it's what you want.

Merry Christmas!