### PR TITLE
Add OAuth options to CreateTunnel / CreateTunnel.Builder

### DIFF
--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
@@ -478,7 +478,7 @@ public class CreateTunnel {
          *
          * @param tunnelDefinition The map from which <code>null</code> attributes will be populated.
          */
-        public void withTunnelDefinition(Map<String, Object> tunnelDefinition) {
+        public Builder withTunnelDefinition(Map<String, Object> tunnelDefinition) {
             if (isNull(this.proto) && tunnelDefinition.containsKey("proto")) {
                 this.proto = Proto.valueOf(((String) tunnelDefinition.get("proto")).toUpperCase());
             }
@@ -524,9 +524,9 @@ public class CreateTunnel {
             if (isNull(this.schemes) && tunnelDefinition.containsKey("schemes")) {
                 this.basicAuth = (List<String>) tunnelDefinition.get("basic_auth");
             }
-			if (isNull(this.oauth) && tunnelDefinition.containsKey("oauth")) {
-                this.oauth = (OAuth) tunnelDefinition.get("oauth");
-            }
+            //Returning this to allow chained configuration of
+            //properties not visible in ngrok's GET /api/tunnels endpoint 
+            return this;
         }
 
         public CreateTunnel build() {

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
@@ -77,6 +77,7 @@ public class CreateTunnel {
     private final String metadata;
     private final List<String> schemes;
     private final List<String> basicAuth;
+	private final OAuth oauth;
 
     private CreateTunnel(final Builder builder) {
         this.ngrokVersion = builder.ngrokVersion;
@@ -96,6 +97,7 @@ public class CreateTunnel {
         this.metadata = builder.metadata;
         this.schemes = builder.schemes;
         this.basicAuth = builder.basicAuth;
+		this.oauth = builder.oauth;
     }
 
     /**
@@ -210,6 +212,13 @@ public class CreateTunnel {
     public List<String> getSchemes() {
         return schemes;
     }
+	
+	/**
+     * Get the OAuth settings to be activated on the tunnel
+     */
+    public OAuth getOauth() {
+      return oauth;
+    }
 
     /**
      * Builder for a {@link CreateTunnel}, which can be used to construct a request that conforms to
@@ -236,6 +245,7 @@ public class CreateTunnel {
         private String metadata;
         private List<String> schemes;
         private List<String> basicAuth;
+		private OAuth oauth;
 
         /**
          * Use this constructor if default values should not be populated in required attributes when {@link #build()}
@@ -283,6 +293,7 @@ public class CreateTunnel {
             this.metadata = createTunnel.metadata;
             this.schemes = createTunnel.schemes;
             this.basicAuth = createTunnel.basicAuth;
+			this.oauth = createTunnel.oauth;
         }
 
         /**
@@ -452,6 +463,14 @@ public class CreateTunnel {
             this.basicAuth = basicAuth;
             return this;
         }
+		
+		/**
+		 * Set of OAuth settings to enable OAuth authentication on the tunnel endpoint
+		 */
+		public Builder withOAuth(OAuth oauth) {
+          this.oauth = oauth;
+          return this;
+        }
 
         /**
          * Populate any <code>null</code> attributes (with the exception of <code>name</code>) in this Builder with
@@ -504,6 +523,9 @@ public class CreateTunnel {
             }
             if (isNull(this.schemes) && tunnelDefinition.containsKey("schemes")) {
                 this.basicAuth = (List<String>) tunnelDefinition.get("basic_auth");
+            }
+			if (isNull(this.oauth) && tunnelDefinition.containsKey("oauth")) {
+                this.oauth = (OAuth) tunnelDefinition.get("oauth");
             }
         }
 

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/OAuth.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/OAuth.java
@@ -1,0 +1,92 @@
+package com.github.alexdlaird.ngrok.protocol;
+
+import static java.util.Objects.*;
+
+import java.util.Arrays;
+import java.util.List;
+import com.google.gson.annotations.SerializedName;
+
+public class OAuth {
+
+  public static class Builder {
+    private String provider;
+    private List<String> scopes;
+    private List<String> allowEmails;
+    private List<String> allowDomains;
+
+    /**
+     * The OAuth Provider. This setting is <b>required</b>. Valid examples for
+     * provider are: amazon, facebook, github, gitlab, google, linkedin, microsoft, twitch 
+     */
+    public Builder withProvider(final String provider) {
+      this.provider = provider;
+      return this;
+    }
+
+    /**
+     * The OAuth Scopes
+     */
+    public Builder withScopes(final String... scopes) {
+      this.scopes = Arrays.asList(scopes);
+      return this;
+    }
+
+    /**
+     * The OAuth Emails
+     */
+    public Builder withAllowEmails(final String... emails) {
+      this.allowEmails = Arrays.asList(emails);
+      return this;
+    }
+
+    /**
+     * The OAuth Domains
+     */
+    public Builder withAllowDomains(final String... domains) {
+      this.allowDomains = Arrays.asList(domains);
+      return this;
+    }
+
+    public OAuth build() {
+      if (isNull(provider)) {
+        throw new IllegalArgumentException("OAuth needs a provider set");
+      }
+      return new OAuth(this);
+    }
+  }
+
+  private String provider;
+
+  @SerializedName("oauth_scopes")
+  private List<String> scopes;
+
+  @SerializedName("allow_emails")
+  private List<String> allowEmails;
+
+  @SerializedName("allow_domains")
+  private List<String> allowDomains;
+
+  private OAuth(Builder builder) {
+    this.provider = builder.provider;
+    this.scopes = builder.scopes;
+    this.allowDomains = builder.allowDomains;
+    this.allowEmails = builder.allowEmails;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public List<String> getScopes() {
+    return scopes;
+  }
+
+  public List<String> getAllowEmails() {
+    return allowEmails;
+  }
+
+  public List<String> getAllowDomains() {
+    return allowDomains;
+  }
+
+}

--- a/src/test/java/com/github/alexdlaird/ngrok/protocol/CreateTunnelTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/protocol/CreateTunnelTest.java
@@ -28,10 +28,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CreateTunnelTest {
 
@@ -98,5 +101,39 @@ public class CreateTunnelTest {
         assertThrows(IllegalArgumentException.class, () -> new CreateTunnel.Builder()
                 .withSchemes(List.of("http", "https"))
                 .withBindTls(BindTls.TRUE));
+    }
+    
+    @Test
+    public void testCreateTunnelOAuth() {
+        // WHEN
+        final CreateTunnel createTunnel = new CreateTunnel.Builder()
+                  .withOAuth(new OAuth.Builder().withProvider("testcase")
+                  .withAllowDomains("one.domain", "two.domain")
+                  .withAllowEmails("one@email", "two@email")
+                  .withScopes("ascope", "bscope")
+                .build()).build();
+
+        // THEN
+        assertNotNull(createTunnel.getOauth());
+        assertEquals("testcase", createTunnel.getOauth().getProvider());
+        assertTrue(createTunnel.getOauth().getAllowDomains().contains("one.domain"));
+        assertTrue(createTunnel.getOauth().getAllowEmails().contains("two@email"));
+        assertTrue(createTunnel.getOauth().getScopes().contains("ascope"));
+    }
+    
+    @Test
+    public void testCreateTunnelNoOAuthWithoutProvider() throws Exception {
+        // WHEN
+        try {
+          new CreateTunnel.Builder()
+                  .withOAuth(new OAuth.Builder()
+                    .withAllowDomains("one.domain", "two.domain")
+                    .withAllowEmails("one@email", "two@email")
+                    .withScopes("ascope", "bscope").build())
+                  .build();
+          fail("no provider should throw an exception");
+        } catch(IllegalArgumentException iae) {
+          //This is correct.
+        }        
     }
 }


### PR DESCRIPTION
**Description**
This change fixes issue 63 by adding OAuth support into CreateTunnel / CreateTunnel.Builder, allowing to configure OAuth secured tunnels through java-ngrok

**Issues**
(https://github.com/alexdlaird/java-ngrok/issues/63)

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Testing Done**
Tests were added to ensure data set in the Builder is passed into CreateTunnel and to make sure that not OAuth information is passed if no provider is set. 

**Checklist**
- [X] My code follows the Google Java Style Guide
- [X] I have performed a self-review of my own code
- [X] I have commented my code in particularly hard-to-understand areas
- [x] If applicable, I have made corresponding changes to the documentation
- [x] I have added tests that prove my change is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My changes generate no new warnings
