### PR TITLE
Add Support for Labels / Cloud Edge

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,14 +7,23 @@ on:
   pull_request:
     branches: [ main, develop ]
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "0 10 * * *"
 
 jobs:
   build:
     name: Build
 
+    env:
+      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
+      NGROK_HTTP_EDGE: ${{ secrets.NGROK_HTTP_EDGE }}
+      NGROK_TCP_EDGE: ${{ secrets.NGROK_TCP_EDGE }}
+      NGROK_API_KEY: ${{ secrets.NGROK_API_KEY }}
+      NGROK_HTTP_EDGE_ENDPOINT: ${{ secrets.NGROK_HTTP_EDGE_ENDPOINT }}
+      NGROK_TCP_EDGE_ENDPOINT: ${{ secrets.NGROK_TCP_EDGE_ENDPOINT }}
+
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         java-version: [ 11 ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
-name: "CI/CD"
+name: "CI Tests"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "**"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: "CI/CD"
+name: "CD"
 
 on:
   release:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,14 @@ jobs:
   deploy:
     name: Deploy
 
+    env:
+      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
+      NGROK_HTTP_EDGE: ${{ secrets.NGROK_HTTP_EDGE }}
+      NGROK_TCP_EDGE: ${{ secrets.NGROK_TCP_EDGE }}
+      NGROK_API_KEY: ${{ secrets.NGROK_API_KEY }}
+      NGROK_HTTP_EDGE_ENDPOINT: ${{ secrets.NGROK_HTTP_EDGE_ENDPOINT }}
+      NGROK_TCP_EDGE_ENDPOINT: ${{ secrets.NGROK_TCP_EDGE_ENDPOINT }}
+
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support for `labels`, so [`ngrok`'s Labeled Tunnel Configuration](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#labeled-tunnel-configuration-properties) is now supported, which enables basic support for [`ngrok`'s Cloud Edge](https://ngrok.com/docs/cloud-edge/).
 - `apiKey` to [`JavaNgrokConfig`](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/2.2.0/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.html), which can be set so `java-ngrok` can interface with Cloud Edge `labels`.
 - `id` to [Tunnel](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/2.2.0/com.github.alexdlaird.ngrok/com/github/alexdlaird/ngrok/protocol/Tunnel.html).
+- `timeout` to [DefaultHttpClient](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/2.2.0/com.github.alexdlaird.ngrok/com/github/alexdlaird/http/DefaultHttpClient.html).
 - Documentation improvements.
 - Test improvements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/alexdlaird/java-ngrok/compare/2.1.0...HEAD)
+## [Unreleased](https://github.com/alexdlaird/java-ngrok/compare/2.2.0...HEAD)
+
+## [2.2.0](https://github.com/alexdlaird/java-ngrok/compare/2.1.0...2.2.0) - TBD
 ### Added
+- Support for `labels`, so [`ngrok`'s Labeled Tunnel Configuration](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#labeled-tunnel-configuration-properties) is now supported, which enables basic support for [`ngrok`'s Cloud Edge](https://ngrok.com/docs/cloud-edge/).
+- `apiKey` to [`JavaNgrokConfig`](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/2.2.0/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.html), which can be set so `java-ngrok` can interface with Cloud Edge `labels`.
+- Documentation improvements.
 - Test improvements.
 
 ## [2.1.0](https://github.com/alexdlaird/java-ngrok/compare/2.0.0...2.1.0) - 2023-04-22
@@ -97,8 +102,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.1.0](https://github.com/alexdlaird/java-ngrok/compare/1.0.0...1.1.0) - 2021-08-20
 ### Added
-- Support for [`ngrok`'s tunnel definitions](https://ngrok.com/docs#tunnel-definitions) when calling [NgrokClient.connect()](https://javadoc.io/static/com.github.alexdlaird/java-ngrok/1.1.0/com/github/alexdlaird/ngrok/NgrokClient.html#connect(com.github.alexdlaird.ngrok.protocol.CreateTunnel)). If a tunnel definition in `ngrok`'s config matches the given `name`, it will be used to start the tunnel.
-- Support for a [`ngrok` tunnel definition](https://ngrok.com/docs#tunnel-definitions) named "java-ngrok-default" when calling [NgrokClient.connect()](https://javadoc.io/static/com.github.alexdlaird/java-ngrok/1.1.0/com/github/alexdlaird/ngrok/NgrokClient.html#connect(com.github.alexdlaird.ngrok.protocol.CreateTunnel)). When `name` is `None` and a "java-ngrok-default" tunnel definition exists it `ngrok`'s config, it will be used.
+- Support for [`ngrok`'s tunnel definitions](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions) when calling [NgrokClient.connect()](https://javadoc.io/static/com.github.alexdlaird/java-ngrok/1.1.0/com/github/alexdlaird/ngrok/NgrokClient.html#connect(com.github.alexdlaird.ngrok.protocol.CreateTunnel)). If a tunnel definition in `ngrok`'s config matches the given `name`, it will be used to start the tunnel.
+- Support for a [`ngrok` tunnel definition](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions) named "java-ngrok-default" when calling [NgrokClient.connect()](https://javadoc.io/static/com.github.alexdlaird/java-ngrok/1.1.0/com/github/alexdlaird/ngrok/NgrokClient.html#connect(com.github.alexdlaird.ngrok.protocol.CreateTunnel)). When `name` is `None` and a "java-ngrok-default" tunnel definition exists it `ngrok`'s config, it will be used.
 - `refreshMetrics()` to [NgrokClient](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/1.1.0/com/github/alexdlaird/ngrok/NgrokClient.html).
 - Documentation improvements.
 - Test improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Support for `labels`, so [`ngrok`'s Labeled Tunnel Configuration](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#labeled-tunnel-configuration-properties) is now supported, which enables basic support for [`ngrok`'s Cloud Edge](https://ngrok.com/docs/cloud-edge/).
 - `apiKey` to [`JavaNgrokConfig`](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/2.2.0/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.html), which can be set so `java-ngrok` can interface with Cloud Edge `labels`.
+- `id` to [Tunnel](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/2.2.0/com.github.alexdlaird.ngrok/com/github/alexdlaird/ngrok/protocol/Tunnel.html).
 - Documentation improvements.
 - Test improvements.
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ on [Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.a
 <dependency>
     <groupId>com.github.alexdlaird</groupId>
     <artifactId>java-ngrok</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
 </dependency>
 ```
 
 #### Gradle
 
 ```groovy
-implementation "com.github.alexdlaird:java-ngrok:2.1.0"
+implementation "com.github.alexdlaird:java-ngrok:2.2.0"
 ```
 
 If we want `ngrok` to be available from the command line, [pyngrok](https://github.com/alexdlaird/pyngrok) can be

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 `java-ngrok` is a Java wrapper for `ngrok` that manages its own binary, making `ngrok` available via a convenient Java
 API.
 
-[ngrok](https://ngrok.com) is a reverse proxy tool that opens secure tunnels from public URLs to localhost, perfect for
+[`ngrok`](https://ngrok.com) is a reverse proxy tool that opens secure tunnels from public URLs to localhost, perfect for
 exposing local web servers, building webhook integrations, enabling SSH access, testing chatbots, demoing from your own
 machine, and more, and its made even more powerful with native Java integration through `java-ngrok`.
 
@@ -65,7 +65,7 @@ The [`connect`](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/latest/c
 method can also take
 a [`CreateTunnel`](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/latest/com/github/alexdlaird/ngrok/protocol/CreateTunnel.html) (which can be built
 through [its Builder](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/latest/com/github/alexdlaird/ngrok/protocol/CreateTunnel.Builder.html))
-that allows us to pass additional properties that are [supported by ngrok](https://ngrok.com/docs/ngrok-agent/api#start-tunnel).
+that allows us to pass additional properties that are [supported by `ngrok`](https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions).
 
 Assuming we have also installed [pyngrok](https://github.com/alexdlaird/pyngrok), all features of `ngrok` are available
 on the command line.
@@ -75,7 +75,7 @@ ngrok http 80
 ```
 
 For details on how to fully leverage `ngrok` from the command line,
-see [ngrok's official documentation](https://ngrok.com/docs).
+see [`ngrok`'s official documentation](https://ngrok.com/docs).
 
 ## Documentation
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
     id "jacoco"
     id "idea"
-    id 'com.adarshr.test-logger' version '3.2.0'
+    id "com.adarshr.test-logger" version "3.2.0"
 }
 
 group "com.github.alexdlaird"

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,11 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
     id "jacoco"
     id "idea"
+    id 'com.adarshr.test-logger' version '3.2.0'
 }
 
 group "com.github.alexdlaird"
-version "2.1.0"
+version "2.2.0"
 
 java {
     withJavadocJar()
@@ -31,11 +32,6 @@ dependencies {
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
-
-    testLogging {
-        events "failed"
-        exceptionFormat "full"
-    }
 }
 
 jacoco {

--- a/src/main/java/com/github/alexdlaird/http/DefaultHttpClient.java
+++ b/src/main/java/com/github/alexdlaird/http/DefaultHttpClient.java
@@ -74,10 +74,12 @@ public class DefaultHttpClient implements HttpClient {
     private final Gson gson;
     private final String encoding;
     private final String contentType;
+    private final int timeout;
 
     private DefaultHttpClient(final Builder builder) {
         this.encoding = builder.encoding;
         this.contentType = builder.contentType;
+        this.timeout = builder.timeout;
         this.gson = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
@@ -216,6 +218,8 @@ public class DefaultHttpClient implements HttpClient {
         try {
             httpUrlConnection = createHttpUrlConnection(url);
             httpUrlConnection.setRequestMethod(method);
+            httpUrlConnection.setConnectTimeout(timeout);
+            httpUrlConnection.setReadTimeout(timeout);
 
             appendDefaultsToConnection(httpUrlConnection, additionalHeaders);
             modifyConnection(httpUrlConnection);
@@ -279,6 +283,7 @@ public class DefaultHttpClient implements HttpClient {
     public static class Builder {
         private String encoding = "UTF-8";
         private String contentType = "application/json";
+        public int timeout = 4000;
 
         /**
          * Default encoding for requests.
@@ -293,6 +298,14 @@ public class DefaultHttpClient implements HttpClient {
          */
         public Builder withContentType(final String contentType) {
             this.contentType = contentType;
+            return this;
+        }
+
+        /**
+         * Default timeout for requests.
+         */
+        public Builder withTimeout(final int timeout) {
+            this.timeout = timeout;
             return this;
         }
 

--- a/src/main/java/com/github/alexdlaird/ngrok/NgrokClient.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/NgrokClient.java
@@ -141,7 +141,7 @@ public class NgrokClient {
 
     private static final Logger LOGGER = Logger.getLogger(String.valueOf(NgrokClient.class));
 
-    private static final String VERSION = "2.1.0";
+    private static final String VERSION = "2.2.0";
 
     private final JavaNgrokConfig javaNgrokConfig;
     private final NgrokProcess ngrokProcess;

--- a/src/main/java/com/github/alexdlaird/ngrok/NgrokClient.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/NgrokClient.java
@@ -208,9 +208,45 @@ public class NgrokClient {
             tunnel = response.getBody();
         }
 
+        applyCloudEdgeToTunnel(tunnel);
+
         currentTunnels.put(tunnel.getPublicUrl(), tunnel);
 
         return tunnel;
+    }
+
+    private void applyCloudEdgeToTunnel(final Tunnel tunnel) {
+        if ((isNull(tunnel.getPublicUrl()) || tunnel.getPublicUrl().isEmpty())
+                && nonNull(javaNgrokConfig.getApiKey()) && nonNull(tunnel.getId())) {
+            final Map<String, String> ngrokApiHeaders = Map.of(
+                    "Authorization", String.format("Bearer %s", javaNgrokConfig.getApiKey()),
+                    "Ngrok-Version", "2");
+            final Response<Map> tunnelResponse = httpClient.get(String.format("https://api.ngrok.com/tunnels/%s", tunnel.getId()), List.of(), ngrokApiHeaders, Map.class);
+
+            if (!tunnelResponse.getBody().containsKey("labels") || !(tunnelResponse.getBody().get("labels") instanceof Map) || !((Map) tunnelResponse.getBody().get("labels")).containsKey("edge")) {
+                throw new JavaNgrokException(String.format("Tunnel %s does not have 'labels', use a Tunnel configured on Cloud Edge.", tunnel.getId()));
+            }
+
+            final String edge = (String) ((Map) tunnelResponse.getBody().get("labels")).get("edge");
+            final String edgesPrefix;
+            if (edge.startsWith("edghts_")) {
+                edgesPrefix = "https";
+            } else if (edge.startsWith("edgtcp")) {
+                edgesPrefix = "tcp";
+            } else if (edge.startsWith("edgtls")) {
+                edgesPrefix = "tls";
+            } else {
+                throw new JavaNgrokException(String.format("Unknown Edge prefix: %s.", edge));
+            }
+
+            final Response<Map> edgeResponse = httpClient.get(String.format("https://api.ngrok.com/edges/%s/%s", edgesPrefix, edge), List.of(), ngrokApiHeaders, Map.class);
+
+            if (!edgeResponse.getBody().containsKey("hostports") || !(edgeResponse.getBody().get("hostports") instanceof List) || ((List) edgeResponse.getBody().get("hostports")).isEmpty()) {
+                throw new JavaNgrokException(String.format("No Endpoint is attached to your Cloud Edge %s, login to the ngrok dashboard to attach an Endpoint to your Edge first.", edge));
+            }
+
+            tunnel.appleCloudEdge(String.format("%s://%s", edgesPrefix, ((List) edgeResponse.getBody().get("hostports")).get(0)), edgesPrefix);
+        }
     }
 
     /**
@@ -270,6 +306,7 @@ public class NgrokClient {
 
             currentTunnels.clear();
             for (final Tunnel tunnel : response.getBody().getTunnels()) {
+                applyCloudEdgeToTunnel(tunnel);
                 currentTunnels.put(tunnel.getPublicUrl(), tunnel);
             }
 
@@ -374,6 +411,10 @@ public class NgrokClient {
         }
 
         if (nonNull(name) && tunnelDefinitions.containsKey(name)) {
+            if (((Map<String, Object>) tunnelDefinitions.get(name)).containsKey("labels") && isNull(javaNgrokConfig.getApiKey())) {
+                throw new JavaNgrokException("'JavaNgrokConfig.apiKey' must be set when 'labels' is on the tunnel definition.");
+            }
+
             createTunnelBuilder.withTunnelDefinition((Map<String, Object>) tunnelDefinitions.get(name));
         }
 

--- a/src/main/java/com/github/alexdlaird/ngrok/NgrokClient.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/NgrokClient.java
@@ -94,7 +94,7 @@ import static java.util.Objects.nonNull;
  * <p>
  * The {@link NgrokClient#connect(CreateTunnel) NgrokClient.connect()} method can also take a {@link CreateTunnel}
  * (which can be built through {@link CreateTunnel.Builder its Builder}) that allows us to pass additional properties
- * that are <a href="https://ngrok.com/docs/ngrok-agent/api#start-tunnel" target="_blank">supported by ngrok</a>.
+ * that are <a href="https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions" target="_blank">supported by ngrok</a>.
  * <p>
  * <p>
  * <code>java-ngrok</code> is compatible with <code>ngrok</code> v2 and v3, but by default it will install v3. To

--- a/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
@@ -69,6 +69,7 @@ public class JavaNgrokConfig {
     private final Function<NgrokLog, Void> logEventCallback;
     private final int startupTimeout;
     private final NgrokVersion ngrokVersion;
+    private final String apiKey;
 
     private JavaNgrokConfig(final Builder builder) {
         this.ngrokPath = builder.ngrokPath;
@@ -80,6 +81,7 @@ public class JavaNgrokConfig {
         this.logEventCallback = builder.logEventCallback;
         this.startupTimeout = builder.startupTimeout;
         this.ngrokVersion = builder.ngrokVersion;
+        this.apiKey = builder.apiKey;
     }
 
     /**
@@ -97,7 +99,7 @@ public class JavaNgrokConfig {
     }
 
     /**
-     * Get the authtoken that will be passed to commands.
+     * Get the <code>ngrok</code> authtoken that will be passed to commands.
      */
     public String getAuthToken() {
         return authToken;
@@ -146,6 +148,13 @@ public class JavaNgrokConfig {
     }
 
     /**
+     * A <code>ngrok</code> API key.
+     */
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    /**
      * Builder for a {@link JavaNgrokConfig}, see docs for that class for example usage.
      */
     public static class Builder {
@@ -159,6 +168,7 @@ public class JavaNgrokConfig {
         private Function<NgrokLog, Void> logEventCallback;
         private int startupTimeout = 15;
         private NgrokVersion ngrokVersion = NgrokVersion.V3;
+        private String apiKey;
 
         public Builder() {
         }
@@ -178,6 +188,7 @@ public class JavaNgrokConfig {
             this.logEventCallback = javaNgrokConfig.logEventCallback;
             this.startupTimeout = javaNgrokConfig.startupTimeout;
             this.ngrokVersion = javaNgrokConfig.ngrokVersion;
+            this.apiKey = javaNgrokConfig.apiKey;
         }
 
         /**
@@ -197,7 +208,7 @@ public class JavaNgrokConfig {
         }
 
         /**
-         * An authtoken to pass to commands (overrides what is in the config).
+         * A <code>ngrok</code> authtoken to pass to commands (overrides what is in the config).
          */
         public Builder withAuthToken(final String authToken) {
             this.authToken = authToken;
@@ -259,6 +270,14 @@ public class JavaNgrokConfig {
          */
         public Builder withNgrokVersion(final NgrokVersion ngrokVersion) {
             this.ngrokVersion = ngrokVersion;
+            return this;
+        }
+
+        /**
+         * A <code>ngrok</code> API key.
+         */
+        public Builder withApiKey(final String apiKey) {
+            this.apiKey = apiKey;
             return this;
         }
 

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/BindTls.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/BindTls.java
@@ -27,7 +27,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * An enum representing <code>ngrok</code>'s valid <code>bind_tls</code> values, as defined in
- * <a href="https://ngrok.com/docs/ngrok-agent/api#start-tunnel" target="_blank"><code>ngrok</code>'s docs</a>.
+ * <a href="https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions" target="_blank"><code>ngrok</code>'s docs</a>.
  */
 public enum BindTls {
     @SerializedName("true")

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
@@ -23,6 +23,7 @@
 
 package com.github.alexdlaird.ngrok.protocol;
 
+import com.github.alexdlaird.exception.JavaNgrokException;
 import com.github.alexdlaird.http.HttpClient;
 import com.github.alexdlaird.ngrok.NgrokClient;
 import com.github.alexdlaird.ngrok.conf.JavaNgrokConfig;
@@ -88,6 +89,7 @@ public class CreateTunnel {
     private final TunnelHeader responseHeader;
     private final TunnelIPRestrictions ipRestrictions;
     private final TunnelVerifyWebhook verifyWebhook;
+    private final List<String> labels;
 
     private CreateTunnel(final Builder builder) {
         this.ngrokVersion = builder.ngrokVersion;
@@ -118,6 +120,7 @@ public class CreateTunnel {
         this.responseHeader = builder.responseHeader;
         this.ipRestrictions = builder.ipRestrictions;
         this.verifyWebhook = builder.verifyWebhook;
+        this.labels = builder.labels;
     }
 
     /**
@@ -318,6 +321,13 @@ public class CreateTunnel {
     }
 
     /**
+     * Get the labels.
+     */
+    public List<String> getLabels() {
+        return labels;
+    }
+
+    /**
      * Builder for a {@link CreateTunnel}, which can be used to construct a request that conforms to
      * <a href="https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions" target="_blank"><code>ngrok</code>'s tunnel definition</a>.
      * See docs for that class for example usage.
@@ -353,6 +363,7 @@ public class CreateTunnel {
         private TunnelHeader responseHeader;
         private TunnelIPRestrictions ipRestrictions;
         private TunnelVerifyWebhook verifyWebhook;
+        private List<String> labels;
 
         /**
          * Use this constructor if default values should not be populated in required attributes when {@link #build()}
@@ -754,6 +765,13 @@ public class CreateTunnel {
             if (isNull(this.verifyWebhook) && tunnelDefinition.containsKey("verify_webhook")) {
                 this.verifyWebhook = new TunnelVerifyWebhook.Builder((Map<String, Object>) tunnelDefinition.get("verify_webhook")).build();
             }
+            if (tunnelDefinition.containsKey("labels")) {
+                if (nonNull(bindTls)) {
+                    throw new IllegalArgumentException("'bindTls' cannot be set when 'labels' is also on the tunnel definition.");
+                }
+                this.labels = (List<String>) tunnelDefinition.get("labels");
+            }
+
             // Returning this to allow chained configuration of
             // properties not visible in ngrok's GET /api/tunnels endpoint
             return this;
@@ -765,7 +783,7 @@ public class CreateTunnel {
             }
 
             if (setDefaults) {
-                if (isNull(proto)) {
+                if (isNull(proto) && isNull(labels)) {
                     proto = Proto.HTTP;
                 }
                 if (isNull(addr)) {

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/CreateTunnel.java
@@ -319,7 +319,7 @@ public class CreateTunnel {
 
     /**
      * Builder for a {@link CreateTunnel}, which can be used to construct a request that conforms to
-     * <a href="https://ngrok.com/docs/ngrok-agent/api#start-tunnel" target="_blank"><code>ngrok</code>'s tunnel definition</a>.
+     * <a href="https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions" target="_blank"><code>ngrok</code>'s tunnel definition</a>.
      * See docs for that class for example usage.
      */
     public static class Builder {

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/Proto.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/Proto.java
@@ -27,7 +27,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * An enum representing <code>ngrok</code>'s valid protos, as defined in
- * <a href="https://ngrok.com/docs/ngrok-agent/api#start-tunnel" target="_blank"><code>ngrok</code>'s docs</a>.
+ * <a href="https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions" target="_blank"><code>ngrok</code>'s docs</a>.
  */
 public enum Proto {
     @SerializedName("http")

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/Tunnel.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/Tunnel.java
@@ -23,6 +23,8 @@
 
 package com.github.alexdlaird.ngrok.protocol;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.Map;
 
 /**
@@ -30,12 +32,21 @@ import java.util.Map;
  */
 public class Tunnel {
 
+    @SerializedName("ID")
+    private String id;
     private String name;
     private String uri;
     private String publicUrl;
     private String proto;
     private TunnelConfig config;
     private Map<String, Metrics> metrics;
+
+    /**
+     * Get the ID of the tunnel.
+     */
+    public String getId() {
+        return id;
+    }
 
     /**
      * Get the name of the tunnel.
@@ -86,6 +97,11 @@ public class Tunnel {
      */
     public void setMetrics(final Map<String, Metrics> metrics) {
         this.metrics = metrics;
+    }
+
+    public void appleCloudEdge(final String publicUrl, final String proto) {
+        this.publicUrl = publicUrl;
+        this.proto = proto;
     }
 
     public static class TunnelConfig {

--- a/src/main/java/com/github/alexdlaird/ngrok/protocol/TunnelOAuth.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/protocol/TunnelOAuth.java
@@ -72,7 +72,7 @@ public class TunnelOAuth {
 
     /**
      * Builder for OAuth configuration that conforms to
-     * <a href="https://ngrok.com/docs/ngrok-agent/config/#tunnel-definitions" target="_blank"><code>ngrok</code>'s tunnel definition</a>.
+     * <a href="https://ngrok.com/docs/secure-tunnels/ngrok-agent/reference/config/#tunnel-definitions" target="_blank"><code>ngrok</code>'s tunnel definition</a>.
      * See docs for that class for example usage.
      */
     public static class Builder {

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -18,14 +18,14 @@ demoing from your own machine, and more, and its made even more powerful with na
 &lt;dependency&gt;
     &lt;groupId&gt;com.github.alexdlaird&lt;/groupId&gt;
     &lt;artifactId&gt;java-ngrok&lt;/artifactId&gt;
-    &lt;version&gt;2.1.0&lt;/version&gt;
+    &lt;version&gt;2.2.0&lt;/version&gt;
 &lt;/dependency&gt;
 </pre>
 
 <h3>Gradle</h3>
 
 <pre>
-implementation "com.github.alexdlaird:java-ngrok:2.1.0"
+implementation "com.github.alexdlaird:java-ngrok:2.2.0"
 </pre>
 
 If we want <code>ngrok</code> to be available from the command line,

--- a/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
@@ -83,10 +83,10 @@ class NgrokClientTest extends NgrokTestCase {
     @Test
     public void testGetters() {
         // THEN
-        assertEquals(javaNgrokConfigV2, ngrokClientV2.getJavaNgrokConfig());
-        assertEquals(ngrokProcessV2, ngrokClientV2.getNgrokProcess());
-        assertEquals(ngrokInstaller, ngrokClientV2.getNgrokProcess().getNgrokInstaller());
-        assertNotNull(ngrokClientV2.getHttpClient());
+        assertEquals(javaNgrokConfigV3, ngrokClientV3.getJavaNgrokConfig());
+        assertEquals(ngrokProcessV3, ngrokClientV3.getNgrokProcess());
+        assertEquals(ngrokInstaller, ngrokClientV3.getNgrokProcess().getNgrokInstaller());
+        assertNotNull(ngrokClientV3.getHttpClient());
     }
 
     @Test
@@ -565,7 +565,7 @@ class NgrokClientTest extends NgrokTestCase {
         assertEquals("https", tunnel.getProto());
         assertEquals("file:///", tunnel.getConfig().getAddr());
         assertNotNull(tunnel.getPublicUrl());
-        assertThat(tunnel.getPublicUrl(), startsWith("http://"));
+        assertThat(tunnel.getPublicUrl(), startsWith("https://"));
     }
 
     @Test
@@ -914,14 +914,14 @@ class NgrokClientTest extends NgrokTestCase {
         final Tunnel ngrokTunnel2 = ngrokClient2.connect(createTunnelSubdomain);
 
         // THEN
-        assertEquals("java-ngrok-default (http)", ngrokTunnel1.getName());
+        assertEquals("java-ngrok-default", ngrokTunnel1.getName());
         assertEquals("http://localhost:8080", ngrokTunnel1.getConfig().getAddr());
-        assertEquals("http", ngrokTunnel1.getProto());
-        assertEquals(String.format("http://%s.ngrok.io", subdomain1), ngrokTunnel1.getPublicUrl());
-        assertEquals("java-ngrok-default (http)", ngrokTunnel2.getName());
+        assertEquals("https", ngrokTunnel1.getProto());
+        assertEquals(String.format("https://%s.ngrok.io", subdomain1), ngrokTunnel1.getPublicUrl());
+        assertEquals("java-ngrok-default", ngrokTunnel2.getName());
         assertEquals("http://localhost:5000", ngrokTunnel2.getConfig().getAddr());
-        assertEquals("http", ngrokTunnel2.getProto());
-        assertEquals(String.format("http://%s.ngrok.io", subdomain2), ngrokTunnel2.getPublicUrl());
+        assertEquals("https", ngrokTunnel2.getProto());
+        assertEquals(String.format("https://%s.ngrok.io", subdomain2), ngrokTunnel2.getPublicUrl());
     }
 
     @Test

--- a/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
@@ -569,26 +569,26 @@ class NgrokClientTest extends NgrokTestCase {
     }
 
     @Test
-    public void testDisconnectFileserver() throws InterruptedException {
+    public void testDisconnectFileserverV2() throws InterruptedException {
         final String ngrokAuthToken = System.getenv("NGROK_AUTHTOKEN");
         assumeTrue(isNotBlank(System.getenv("NGROK_AUTHTOKEN")), "NGROK_AUTHTOKEN environment variable not set");
 
         // GIVEN
-        ngrokClientV3.getNgrokProcess().setAuthToken(ngrokAuthToken);
-        assertFalse(ngrokClientV3.getNgrokProcess().isRunning());
+        ngrokClientV2.getNgrokProcess().setAuthToken(ngrokAuthToken);
+        assertFalse(ngrokClientV2.getNgrokProcess().isRunning());
         final CreateTunnel createTunnel = new CreateTunnel.Builder()
                 .withAddr("file:///")
                 .build();
-        final String publicUrl = ngrokClientV3.connect(createTunnel).getPublicUrl();
+        final String publicUrl = ngrokClientV2.connect(createTunnel).getPublicUrl();
         Thread.sleep(1000);
 
         // WHEN
-        ngrokClientV3.disconnect(publicUrl);
+        ngrokClientV2.disconnect(publicUrl);
         Thread.sleep(1000);
-        final List<Tunnel> tunnels = ngrokClientV3.getTunnels();
+        final List<Tunnel> tunnels = ngrokClientV2.getTunnels();
 
         // THEN
-        assertTrue(ngrokClientV3.getNgrokProcess().isRunning());
+        assertTrue(ngrokClientV2.getNgrokProcess().isRunning());
         // There is still one tunnel left, as we only disconnected the http tunnel
         assertEquals(1, tunnels.size());
     }

--- a/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
@@ -42,7 +42,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/NgrokClientTest.java
@@ -57,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -107,6 +108,7 @@ class NgrokClientTest extends NgrokTestCase {
         // THEN
         assertTrue(ngrokClientV2.getNgrokProcess().getVersion().startsWith("2"));
         assertTrue(ngrokClientV2.getNgrokProcess().isRunning());
+        assertNull(tunnel.getId());
         assertThat(tunnel.getName(), startsWith("http-5000-"));
         assertEquals("http", tunnel.getProto());
         assertEquals("http://localhost:5000", tunnel.getConfig().getAddr());
@@ -141,6 +143,7 @@ class NgrokClientTest extends NgrokTestCase {
         // THEN
         assertTrue(ngrokClientV3.getNgrokProcess().getVersion().startsWith("3"));
         assertTrue(ngrokClientV3.getNgrokProcess().isRunning());
+        assertNotNull(tunnel.getId());
         assertThat(tunnel.getName(), startsWith("http-5000-"));
         assertEquals("https", tunnel.getProto());
         assertEquals("http://localhost:5000", tunnel.getConfig().getAddr());
@@ -800,11 +803,11 @@ class NgrokClientTest extends NgrokTestCase {
                 .withNgrokVersion(NgrokVersion.V3)
                 .withName("edge-http-tunnel")
                 .build();
-        final Tunnel httpEdgeTunnel = ngrokClient2.connect(createHttpEdgeTunnel);
         final CreateTunnel createTcpEdgeTunnel = new CreateTunnel.Builder()
                 .withNgrokVersion(NgrokVersion.V3)
                 .withName("edge-tcp-tunnel")
                 .build();
+        final Tunnel httpEdgeTunnel = ngrokClient2.connect(createHttpEdgeTunnel);
         final Tunnel tcpEdgeTunnel = ngrokClient2.connect(createTcpEdgeTunnel);
         final List<Tunnel> tunnels = ngrokClient2.getTunnels();
         tunnels.sort(Comparator.comparing(Tunnel::getProto));
@@ -817,12 +820,12 @@ class NgrokClientTest extends NgrokTestCase {
         assertEquals("edge-tcp-tunnel", tcpEdgeTunnel.getName());
         assertEquals("tcp://localhost:22", tcpEdgeTunnel.getConfig().getAddr());
         assertEquals("tcp", tcpEdgeTunnel.getProto());
-        assertEquals(ngrokHttpEdgeEndpoint, tcpEdgeTunnel.getPublicUrl());
+        assertEquals(ngrokTcpEdgeEndpoint, tcpEdgeTunnel.getPublicUrl());
         assertEquals(2, tunnels.size());
         assertEquals("edge-http-tunnel", tunnels.get(0).getName());
         assertEquals("http://localhost:80", tunnels.get(0).getConfig().getAddr());
-        assertEquals("http", tunnels.get(0).getProto());
-        assertEquals(ngrokTcpEdgeEndpoint, tunnels.get(0).getPublicUrl());
+        assertEquals("https", tunnels.get(0).getProto());
+        assertEquals(ngrokHttpEdgeEndpoint, tunnels.get(0).getPublicUrl());
         assertEquals("edge-tcp-tunnel", tunnels.get(1).getName());
         assertEquals("tcp://localhost:22", tunnels.get(1).getConfig().getAddr());
         assertEquals("tcp", tunnels.get(1).getProto());

--- a/src/test/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfigTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfigTest.java
@@ -55,6 +55,7 @@ public class JavaNgrokConfigTest {
                 .withLogEventCallback(logEventCallback)
                 .withStartupTimeout(5)
                 .withNgrokVersion(NgrokVersion.V2)
+                .withApiKey("api-key")
                 .build();
 
         // THEN
@@ -67,6 +68,7 @@ public class JavaNgrokConfigTest {
         assertEquals(logEventCallback, javaNgrokConfig.getLogEventCallback());
         assertEquals(5, javaNgrokConfig.getStartupTime());
         assertEquals(NgrokVersion.V2, javaNgrokConfig.getNgrokVersion());
+        assertEquals("api-key", javaNgrokConfig.getApiKey());
     }
 
     @Test

--- a/src/test/java/com/github/alexdlaird/ngrok/process/NgrokProcessTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/process/NgrokProcessTest.java
@@ -185,7 +185,7 @@ public class NgrokProcessTest extends NgrokTestCase {
     }
 
     @Test
-    public void testMultipleProcessesDifferentBinaries() {
+    public void testMultipleProcessesDifferentBinariesV2() {
         // GIVEN
         ngrokInstaller.installDefaultConfig(javaNgrokConfigV2.getConfigPath(), Map.of("web_addr", "localhost:4040"), javaNgrokConfigV2.getNgrokVersion());
         final Path ngrokPathV2_2 = Paths.get(javaNgrokConfigV2.getNgrokPath().getParent().toString(), "2", NgrokInstaller.getNgrokBin());
@@ -282,22 +282,22 @@ public class NgrokProcessTest extends NgrokTestCase {
     }
 
     @Test
-    public void testStartNoBinary() throws IOException, InterruptedException {
+    public void testStartProcessNoBinary() throws IOException, InterruptedException {
         // Due to Windows file locking behavior, wait a beat
         if (NgrokInstaller.getSystem().equals(WINDOWS)) {
             Thread.sleep(1000);
         }
 
         // GIVEN
-        if (Files.exists(javaNgrokConfigV2.getNgrokPath())) {
-            Files.delete(javaNgrokConfigV2.getNgrokPath());
+        if (Files.exists(javaNgrokConfigV3.getNgrokPath())) {
+            Files.delete(javaNgrokConfigV3.getNgrokPath());
         }
 
         // WHEN
-        final NgrokException exception = assertThrows(NgrokException.class, ngrokProcessV2::start);
+        final NgrokException exception = assertThrows(NgrokException.class, ngrokProcessV3::start);
 
         // THEN
         assertThat(exception.getMessage(), containsString("ngrok binary was not found"));
-        assertFalse(ngrokProcessV2.isRunning());
+        assertFalse(ngrokProcessV3.isRunning());
     }
 }

--- a/src/test/java/com/github/alexdlaird/ngrok/protocol/CreateTunnelTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/protocol/CreateTunnelTest.java
@@ -27,6 +27,7 @@ import com.github.alexdlaird.ngrok.installer.NgrokVersion;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -163,5 +164,25 @@ public class CreateTunnelTest {
         assertThrows(IllegalArgumentException.class, () -> new CreateTunnel.Builder()
                 .withBasicAuth(List.of("auth-token"))
                 .withAuth("auth-token"));
+    }
+
+    @Test
+    public void testCreateLabelsWithTunnelDefinitions() {
+        // WHEN
+        final CreateTunnel createTunnel = new CreateTunnel.Builder()
+                .withTunnelDefinition(Map.of("labels", List.of("edge=some-edge-id")))
+                .build();
+
+        // THEN
+        assertNull(createTunnel.getBindTls());
+        assertEquals(1, createTunnel.getLabels().size());
+        assertEquals("edge=some-edge-id", createTunnel.getLabels().get(0));
+    }
+
+    @Test
+    public void testCreateBindTlsLabelsFails() {
+        // WHEN
+        assertThrows(IllegalArgumentException.class, () -> new CreateTunnel.Builder()
+                .withTunnelDefinition(Map.of("bind_tls", true, "labels", List.of("edge=some-edge-id"))));
     }
 }


### PR DESCRIPTION
**Description**
Add support for `labels` in tunnel definitions. This does not add fully parity support for `ngrok`'s new Cloud Edge feature set, but it does allow its basic functionality to be used with `pyngrok` now.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Testing Done**
A clear and concise description of the new tests added to validate the change as well as any manual testing done.

**Checklist**
- [x] My code follows the Google Java Style Guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [x] If applicable, I have made corresponding changes to the documentation
- [x] I have added tests that prove my change is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
