### PR TITLE
Add Support for NGROK_AUTHTOKEN Env Var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/alexdlaird/java-ngrok/compare/2.2.5...HEAD)
+### Added
+- If a value for `authToken` is not set in [`JavaNgrokConfig`](https://javadoc.io/doc/com.github.alexdlaird/java-ngrok/2.2.5/com.github.alexdlaird.ngrok/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.html), it will attempt to use the environment variable `NGROK_AUTHTOKEN` if it is set.
+- Build improvements.
 
 ## [2.2.5](https://github.com/alexdlaird/java-ngrok/compare/2.2.4...2.2.5) - 2023-12-01
 ### Changed

--- a/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.util.function.Function;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 /**
  * An object for managing <code>java-ngrok</code>'s configuration to interact the <code>ngrok</code> binary.
@@ -288,6 +289,10 @@ public class JavaNgrokConfig {
             }
             if (isNull(configPath)) {
                 configPath = NgrokInstaller.DEFAULT_CONFIG_PATH;
+            }
+            final String envAuthToken = System.getenv("NGROK_AUTHTOKEN");
+            if (isNull(authToken) && nonNull(envAuthToken)) {
+                authToken = envAuthToken;
             }
 
             return new JavaNgrokConfig(this);

--- a/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
+++ b/src/main/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfig.java
@@ -210,7 +210,8 @@ public class JavaNgrokConfig {
         }
 
         /**
-         * A <code>ngrok</code> authtoken to pass to commands (overrides what is in the config).
+         * A <code>ngrok</code> authtoken to pass to commands (overrides what is in the config). If not set here, the
+         * {@link Builder} will attempt to use the environment variable <code>NGROK_AUTHTOKEN</code> if it is set.
          */
         public Builder withAuthToken(final String authToken) {
             this.authToken = authToken;

--- a/src/test/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfigTest.java
+++ b/src/test/java/com/github/alexdlaird/ngrok/conf/JavaNgrokConfigTest.java
@@ -28,13 +28,19 @@ import com.github.alexdlaird.ngrok.process.NgrokLog;
 import com.github.alexdlaird.ngrok.protocol.Region;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.function.Function;
 
+import static com.github.alexdlaird.util.StringUtils.isBlank;
+import static com.github.alexdlaird.util.StringUtils.isNotBlank;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class JavaNgrokConfigTest {
     @Test
@@ -81,5 +87,19 @@ public class JavaNgrokConfigTest {
     public void testJavaNgrokConfigWithInvalidStartupTimeout() {
         // WHEN
         assertThrows(IllegalArgumentException.class, () -> new JavaNgrokConfig.Builder().withStartupTimeout(0));
+    }
+
+    @Test
+    public void testAuthTokenSetFromEnv() {
+        // GIVEN
+        final String ngrokAuthToken = System.getenv("NGROK_AUTHTOKEN");
+        assumeTrue(isNotBlank(System.getenv("NGROK_AUTHTOKEN")), "NGROK_AUTHTOKEN environment variable not set");
+
+        // WHEN
+        final JavaNgrokConfig javaNgrokConfig = new JavaNgrokConfig.Builder()
+                .build();
+
+        // THEN
+        assertEquals(ngrokAuthToken, javaNgrokConfig.getAuthToken());
     }
 }


### PR DESCRIPTION
**Description**
If no `authToken` is set in `JavaNgrokConfig`, the Builder will now attempt to use `NGROK_AUTHTOKEN` env var, if it is set.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Testing Done**
New unit test added to validated.

**Checklist**
- [x] My code follows the Google Java Style Guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [x] If applicable, I have made corresponding changes to the documentation
- [x] I have added tests that prove my change is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
