### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/alexdlaird/java-ngrok/security/code-scanning/9](https://github.com/alexdlaird/java-ngrok/security/code-scanning/9)

To resolve this issue, add an explicit `permissions` block to the workflow. The best way to do this is at the job level (inside the `stale` job block), specifying only the permissions needed by the `actions/stale` action: `issues: write` and `pull-requests: write`. If label manipulation is involved, `contents: write` can also be included (since the action may set labels). This should be done by inserting a `permissions:` block right after the job name and before `runs-on`.

Specifically:
- Insert the following block after `stale:` (line 8), before `runs-on`:
  ```yaml
      permissions:
        issues: write
        pull-requests: write
        contents: write
  ```
This limits the GITHUB_TOKEN to only the permissions needed by the action.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
