### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,7 +1,6 @@
 name: "Label Commenter"
 
 permissions:
-  contents: read
   issues: write
 
 on:

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,5 +1,9 @@
 name: "Label Commenter"
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   issues:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/alexdlaird/java-ngrok/security/code-scanning/3](https://github.com/alexdlaird/java-ngrok/security/code-scanning/3)

To fix the problem, explicitly add a `permissions` block to the relevant scope (either for the workflow or specifically for the job) that grants only those permissions required for the job to run. Since the workflow needs to comment on issues, it requires `issues: write`. As a baseline, adding `contents: read` (for minimal other needs) is also recommended, as in the GitHub example. 

The change should be made directly in the `.github/workflows/label-commenter.yml` file, just before the `jobs:` block (to apply to all jobs in this workflow). No external libraries or additional methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
